### PR TITLE
Fix complete transposition

### DIFF
--- a/src/Transposer.php
+++ b/src/Transposer.php
@@ -123,12 +123,13 @@ class Transposer
                             $this->simpleTranspose($chords, intval($value));
                         } elseif(!is_null($song->getKey())) {
                             $this->completeTranspose($chords, $song->getKey(), $value);
-                            $song->setKey($value);
                         }
                     }
                 }
             }
         }
+        
+        $song->setKey($value);
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where setKey was being set too early, so only the first line of the song was being transposed correctly. 

https://github.com/intelektron/chordpro-php/issues/3